### PR TITLE
Add Honestli feedback button and fix footer touch targets

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -761,6 +761,7 @@ a:hover {
 }
 
 .footer-social {
+    position: relative;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -770,6 +771,18 @@ a:hover {
     border-radius: 50%;
     color: var(--muted);
     transition: all 0.25s ease;
+}
+
+/* The circle is sized to sit with the copyright line; the touch target is not.
+   Expanded to the 44px minimum without changing what is drawn. */
+.footer-social::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 44px;
+    height: 44px;
+    transform: translate(-50%, -50%);
 }
 
 .footer-social:hover {

--- a/index.html
+++ b/index.html
@@ -433,6 +433,14 @@
                         <path d="M4.98 3.5C4.98 4.88 3.87 6 2.5 6S0 4.88 0 3.5 1.12 1 2.5 1s2.48 1.12 2.48 2.5zM.24 8.31h4.52V23H.24V8.31zM8.34 8.31h4.33v2h.06c.6-1.14 2.08-2.34 4.28-2.34 4.58 0 5.42 3.01 5.42 6.92V23h-4.51v-7.12c0-1.7-.03-3.88-2.37-3.88-2.37 0-2.73 1.85-2.73 3.76V23H8.34V8.31z" />
                     </svg>
                 </a>
+                <a class="footer-social" href="https://www.honestli.io/@adam-heunis" rel="noopener"
+                    aria-label="Anonymous feedback">
+                    <!-- Drawn to the LinkedIn mark's stem weight and cap height, not typeset,
+                         so both glyphs carry the same ink at 18px. -->
+                    <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
+                        <path d="M4 2h4.4v7.6h7.2V2H20v20h-4.4v-8.2H8.4V22H4z" />
+                    </svg>
+                </a>
                 <span>&copy; Adam Heunis <span id="copyrightYear">2026</span></span>
             </div>
         </div>


### PR DESCRIPTION
Adds a second icon button to the footer social row linking to my Honestli
anonymous-feedback page, and brings both footer icon buttons up to the 44px
minimum touch target.

The button reuses .footer-social unchanged, so it inherits the 38px circle,
the border, and the accent hover — no new CSS was needed for it to sit
correctly beside LinkedIn.

The "H" is an authored SVG path on the same 24x24 viewBox at 18x18 with
fill="currentColor", not a text character. A typed letter would inherit Inter
at a stroke weight and baseline that do not match the LinkedIn glyph, and
would shift as the font loads. It is drawn to carry 89% of the LinkedIn mark's
ink at 91% of its height; the undershoot is deliberate, since a solid capital
reads optically larger than an open logotype at equal height.

Accessible name is "Anonymous feedback" via aria-label, matching the LinkedIn
button's pattern. Note that aria-label is an accessibility attribute — Google
falls back to it for a link with no text, so it serves the SEO intent, but a
visually-hidden span would be the stronger crawler signal if we want it later.

Touch targets: the circles stay 38px, because growing them to 44px would make
the footer visually heavier — that is a design change, not an accessibility
fix. A transparent 44x44 ::after centred on each circle carries the target
while leaving what is drawn untouched. Verified by hit-testing all four
corners and edges of the expanded area on both buttons, confirming a probe
just outside it misses, and checking the two areas clear each other by 13px
and the copyright text by 16px.

Closes #11
Closes #12

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
