### PR TITLE
Ignore .claude/, which is local agent tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ tools/screenshots/
 # Python
 __pycache__/
 *.pyc
+
+# Claude Code working directory. Locally installed agent skills and a
+# launch.json — one machine's tooling, not shared project configuration.
+.claude/


### PR DESCRIPTION
144 files and 3.2MB sitting untracked in the repo root: a locally-installed
copy of an agent skill, plus a launch.json. It is one machine's tooling, not
shared project configuration and not part of the published site, so it should
neither be versioned nor reach a Pages build — the same argument that moved
verify_colors.py and its screenshots out of the root.

It also kept git status permanently dirty, which is the clean-tree check the
working flow runs before starting anything; gh flagged it as an uncommitted
change while opening #15.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
